### PR TITLE
Use default timezone if not set on device

### DIFF
--- a/src/TimeZone.ts
+++ b/src/TimeZone.ts
@@ -28,7 +28,11 @@ export class TimeZone {
       if (platformType === 'AlexaSkill') {
         try {
           const result = await (this.jovo.$alexaSkill! as AlexaSkill).$user.getTimezone();
-          this.jovo.$session.$data.timeZone = result;
+            if(result) {
+              this.jovo.$session.$data.timeZone = result;
+            } else {
+              this.jovo.$session.$data.timeZone = this.getDefaultTimeZone();
+            }
         } catch (error) {
           this.jovo.$session.$data.timeZone = this.getDefaultTimeZone();
         }


### PR DESCRIPTION
Sometimes the Alexa Settings API returns an empty timezone (along the response code 204). The docs (https://developer.amazon.com/en-US/docs/alexa/smapi/alexa-settings-api-reference.html) explain this with "No setting value exists.". I presume these are 3rd party Alexa enabled devices. In this case we should use the default timezone based on the locale of the request.