### PR TITLE
Timezone passed from jovo is not always a string.

### DIFF
--- a/src/TimeZone.ts
+++ b/src/TimeZone.ts
@@ -30,9 +30,11 @@ export class TimeZone {
           this.jovo.$alexaSkill! as AlexaSkill
         ).$user.getTimezone();
 
-        this.jovo.$session.$data.timeZone = result
-          ? result
-          : this.getDefaultTimeZone();
+        if(result && typeof result === 'string') {
+          this.jovo.$session.$data.timeZone = result;
+        } else {
+          trow new Error('The Settings API did not return a valid timeZone.');  
+        }
       } catch (error) {
         this.jovo.$session.$data.timeZone = this.getDefaultTimeZone();
       }


### PR DESCRIPTION
Sometimes the Alexa Settings API returns {"code":"DEPENDENCY_FAILURE","message":"The server encountered an unexpected error"} and this passed trough by Jovo.